### PR TITLE
feat: replace SHA-256 with bcrypt (cost=12) for password hashing

### DIFF
--- a/backend/database/seed.py
+++ b/backend/database/seed.py
@@ -5,7 +5,7 @@ Inserts sample users, properties, bookings, reviews, and adventures.
 
 import sqlite3
 import os
-import hashlib
+import bcrypt
 
 
 DB_PATH = os.environ.get(
@@ -15,8 +15,8 @@ DB_PATH = os.environ.get(
 
 
 def hash_password(password: str) -> str:
-    """Simple password hash for seed data."""
-    return hashlib.sha256(password.encode()).hexdigest()
+    """Hash a password using bcrypt with cost factor 12."""
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12)).decode()
 
 
 def insert_seed_data():

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -10,6 +10,7 @@ MVC Role: MODEL
 
 import re
 import hashlib
+import bcrypt
 from typing import Dict, List, Optional
 from backend.database.connection import execute_query
 
@@ -30,8 +31,20 @@ class User:
 
     @staticmethod
     def hash_password(password: str) -> str:
-        """Hash a password using SHA-256."""
-        return hashlib.sha256(password.encode()).hexdigest()
+        """Hash a password using bcrypt with cost factor 12."""
+        return bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12)).decode()
+
+    @staticmethod
+    def _is_sha256_hash(password_hash: str) -> bool:
+        """Return True if the stored hash looks like a raw SHA-256 hex digest."""
+        return len(password_hash) == 64 and all(c in '0123456789abcdef' for c in password_hash)
+
+    @staticmethod
+    def _verify_password(password: str, password_hash: str) -> bool:
+        """Verify a plaintext password against a stored hash (bcrypt or legacy SHA-256)."""
+        if User._is_sha256_hash(password_hash):
+            return hashlib.sha256(password.encode()).hexdigest() == password_hash
+        return bcrypt.checkpw(password.encode(), password_hash.encode())
 
     @staticmethod
     def validate(email: str, first_name: str, last_name: str,
@@ -114,17 +127,29 @@ class User:
         """
         Authenticate a user with email and password.
 
+        Legacy SHA-256 hashes are transparently migrated to bcrypt on first
+        successful login so that all active accounts eventually use bcrypt.
+
         Returns user dict if credentials are valid, None otherwise.
         """
         user = User.get_by_email(email)
         if not user:
             return None
 
-        if user['password_hash'] != User.hash_password(password):
+        if not User._verify_password(password, user['password_hash']):
             return None
 
         if user['status'] != 'active':
             return None
+
+        # Migrate legacy SHA-256 hash to bcrypt on successful login
+        if User._is_sha256_hash(user['password_hash']):
+            new_hash = User.hash_password(password)
+            execute_query(
+                "UPDATE users SET password_hash=?, updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                (new_hash, user['id']),
+                commit=True
+            )
 
         # Return safe user dict (without password_hash)
         return User.get_by_id(user['id'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==3.0.0
 flask-cors==4.0.0
+bcrypt==4.2.0


### PR DESCRIPTION
Implements US-101 (security epic, phase-1):
- Passwords are now hashed with bcrypt at cost factor 12
- `User.hash_password()` uses bcrypt.hashpw with gensalt(rounds=12)
- `User._verify_password()` transparently handles both bcrypt and
  legacy SHA-256 hashes, enabling zero-downtime migration
- `User.authenticate()` detects legacy SHA-256 hashes on successful
  login and re-hashes with bcrypt, completing the migration on next
  login as required
- `seed.py` updated to seed new accounts with bcrypt hashes
- `bcrypt==4.2.0` added to requirements.txt

Closes #1