### PR TITLE
Enforce secure SECRET_KEY generation (resolves #2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ COPY backend/ ./backend/
 RUN mkdir -p /app/data /app/backend/logs \
     && touch /app/backend/logs/.gitkeep
 
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 EXPOSE 5000
 
 ENV FLASK_ENV=production
@@ -21,4 +24,5 @@ ENV PYTHONUNBUFFERED=1
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:5000/health')" || exit 1
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python", "backend/app.py"]

--- a/README.md
+++ b/README.md
@@ -42,11 +42,17 @@ backend/
 # Install dependencies
 pip install -r requirements.txt
 
+# Generate a secure SECRET_KEY (required — the app refuses to start without one)
+export SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+
 # Run the server
 python backend/app.py
 ```
 
 Visit http://localhost:5000
+
+> **Security requirement:** `SECRET_KEY` must be set to a cryptographically random value.
+> The application will exit immediately if it detects a missing or well-known insecure default key.
 
 ### Demo Accounts
 
@@ -60,6 +66,13 @@ Visit http://localhost:5000
 
 ```bash
 docker-compose up --build
+```
+
+The Docker entrypoint automatically generates a random `SECRET_KEY` if one is not provided.
+To use a persistent key across restarts, pass it explicitly:
+
+```bash
+SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))") docker-compose up --build
 ```
 
 ## Features

--- a/backend/app.py
+++ b/backend/app.py
@@ -64,7 +64,22 @@ logger = setup_logging()
 # ============================================================================
 # CONFIGURATION
 # ============================================================================
-app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev-secret-key-change-in-production')
+_INSECURE_DEFAULTS = {
+    'dev-secret-key-change-in-production',
+    'change-this-in-production',
+    'secret',
+    'supersecret',
+    '',
+}
+
+_secret_key = os.environ.get('SECRET_KEY', '')
+if _secret_key in _INSECURE_DEFAULTS:
+    print("FATAL: SECRET_KEY is not set or uses a known insecure default value.")
+    print("Set a cryptographically random SECRET_KEY environment variable before starting.")
+    print("Generate one with:  python3 -c \"import secrets; print(secrets.token_hex(32))\"")
+    sys.exit(1)
+
+app.config['SECRET_KEY'] = _secret_key
 
 DATABASE_DIR = os.path.join(os.path.dirname(__file__), 'database')
 app.config['DATABASE_PATH'] = os.environ.get(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,10 @@ services:
     ports:
       - "5000:5000"
     environment:
-      - SECRET_KEY=change-this-in-production
+      # SECRET_KEY is intentionally omitted here so the entrypoint generates
+      # a cryptographically random key automatically on each container start.
+      # To use a persistent key (e.g. for production), set SECRET_KEY in a
+      # .env file or pass it via: SECRET_KEY=<value> docker-compose up
       - DATABASE_PATH=/app/data/booking_site.db
       - FLASK_ENV=development
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Auto-generate a cryptographically random SECRET_KEY if not provided.
+# This ensures production containers never start with an insecure default.
+if [ -z "$SECRET_KEY" ]; then
+    export SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+    echo "INFO: No SECRET_KEY provided — generated a random key for this session."
+fi
+
+exec "$@"


### PR DESCRIPTION
- app.py: refuse to start if SECRET_KEY is missing or matches a known
  insecure default (e.g. 'dev-secret-key-change-in-production',
  'change-this-in-production'); exits with a clear error message.
- entrypoint.sh: new Docker entrypoint that auto-generates a
  cryptographically random SECRET_KEY (secrets.token_hex(32)) when
  none is supplied, so containers never start with an empty key.
- Dockerfile: copy and invoke entrypoint.sh via ENTRYPOINT.
- docker-compose.yml: remove hardcoded SECRET_KEY default; rely on
  entrypoint for auto-generation or user-supplied env var.
- README.md: document the SECRET_KEY requirement for local runs and
  Docker, including the one-liner to generate a secure value.

https://claude.ai/code/session_019BhwivHj9RMTGNHjQwPoZx