### PR TITLE
Add CSRF protection to all POST forms via Flask-WTF

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,6 +14,7 @@ import sys
 import sqlite3
 import logging
 from flask import Flask, jsonify, request, session, render_template, redirect, url_for
+from flask_wtf.csrf import CSRFProtect
 
 # Add project root to sys.path
 if __name__ == '__main__' or __package__ is None:
@@ -59,6 +60,7 @@ def setup_logging():
 # APPLICATION INITIALIZATION
 # ============================================================================
 app = Flask(__name__)
+csrf = CSRFProtect(app)
 logger = setup_logging()
 
 # ============================================================================
@@ -197,6 +199,13 @@ def internal_error(error):
 
 @app.errorhandler(403)
 def forbidden(error):
+    return render_template('errors/403.html'), 403
+
+
+from flask_wtf.csrf import CSRFError
+
+@app.errorhandler(CSRFError)
+def handle_csrf_error(error):
     return render_template('errors/403.html'), 403
 
 

--- a/backend/templates/admin/adventures.html
+++ b/backend/templates/admin/adventures.html
@@ -51,11 +51,13 @@
                 <td>
                     {% if ab.status == 'pending' %}
                     <form action="{{ url_for('admin.adventures_approve', ab_id=ab.id) }}" method="POST" style="display:inline">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <button type="submit" class="btn btn-success btn-sm">✓</button>
                     </form>
                     <form action="{{ url_for('admin.adventures_reject', ab_id=ab.id) }}" method="POST"
                           style="display:inline"
                           onsubmit="return confirm('Reject this adventure booking?')">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <button type="submit" class="btn btn-danger btn-sm">✗</button>
                     </form>
                     {% else %}

--- a/backend/templates/admin/booking_detail.html
+++ b/backend/templates/admin/booking_detail.html
@@ -77,6 +77,7 @@
             <h3>Take Action</h3>
             <div class="action-forms">
                 <form action="{{ url_for('admin.bookings_approve', booking_id=booking.id) }}" method="POST" class="action-form">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <div class="form-group">
                         <label for="approve_notes">Note to guest (optional)</label>
                         <input type="text" id="approve_notes" name="admin_notes"
@@ -86,6 +87,7 @@
                 </form>
 
                 <form action="{{ url_for('admin.bookings_reject', booking_id=booking.id) }}" method="POST" class="action-form">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <div class="form-group">
                         <label for="reject_notes">Reason for rejection <span class="required">*</span></label>
                         <input type="text" id="reject_notes" name="admin_notes"

--- a/backend/templates/admin/reviews.html
+++ b/backend/templates/admin/reviews.html
@@ -44,11 +44,13 @@
             {% if review.status == 'pending' %}
             <div class="review-actions">
                 <form action="{{ url_for('admin.reviews_approve', review_id=review.id) }}" method="POST" style="display:inline">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button type="submit" class="btn btn-success btn-sm">✓ Approve</button>
                 </form>
                 <form action="{{ url_for('admin.reviews_reject', review_id=review.id) }}" method="POST"
                       style="display:inline"
                       onsubmit="return confirm('Reject this review?')">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button type="submit" class="btn btn-danger btn-sm">✗ Reject</button>
                 </form>
             </div>

--- a/backend/templates/admin/users.html
+++ b/backend/templates/admin/users.html
@@ -39,6 +39,7 @@
                 <td>
                     {% if user.role != 'admin' %}
                     <form action="{{ url_for('admin.users_update_status', user_id=user.id) }}" method="POST" style="display:inline">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         {% if user.status == 'active' %}
                             <input type="hidden" name="status" value="suspended">
                             <button type="submit" class="btn btn-warning btn-sm"

--- a/backend/templates/adventures/new.html
+++ b/backend/templates/adventures/new.html
@@ -13,6 +13,7 @@
 <div class="form-page">
     <div class="form-card">
         <form action="{{ url_for('portal.adventures_create') }}" method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
             <div class="form-group">
                 <label for="adventure_id">Select Activity</label>

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -29,6 +29,7 @@
                         {% if is_admin %}<span class="role-badge admin">Admin</span>{% endif %}
                     </span>
                     <form action="{{ url_for('auth.logout') }}" method="POST" style="display:inline">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <button type="submit" class="btn btn-ghost btn-sm">Log out</button>
                     </form>
                 </div>

--- a/backend/templates/bookings/new.html
+++ b/backend/templates/bookings/new.html
@@ -13,6 +13,7 @@
 <div class="form-page">
     <div class="form-card">
         <form action="{{ url_for('portal.bookings_create') }}" method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
             <div class="property-preview">
                 <div class="property-preview-info">

--- a/backend/templates/bookings/show.html
+++ b/backend/templates/bookings/show.html
@@ -61,6 +61,7 @@
             {% if booking.status in ['pending', 'approved'] %}
                 <form action="{{ url_for('portal.bookings_cancel', booking_id=booking.id) }}" method="POST"
                       onsubmit="return confirm('Are you sure you want to cancel this booking?')">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button type="submit" class="btn btn-danger">Cancel Booking</button>
                 </form>
             {% endif %}

--- a/backend/templates/feedback/new.html
+++ b/backend/templates/feedback/new.html
@@ -13,6 +13,7 @@
 <div class="form-page form-page-narrow">
     <div class="form-card">
         <form action="{{ url_for('portal.reviews_create') }}" method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="booking_id" value="{{ booking.id }}">
 
             <div class="form-group">

--- a/backend/templates/users/login.html
+++ b/backend/templates/users/login.html
@@ -10,6 +10,7 @@
         </div>
 
         <form action="{{ url_for('auth.do_login') }}" method="POST" class="auth-form">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="form-group">
                 <label for="email">Email address</label>
                 <input type="email" id="email" name="email"

--- a/backend/templates/users/register.html
+++ b/backend/templates/users/register.html
@@ -10,6 +10,7 @@
         </div>
 
         <form action="{{ url_for('auth.do_register') }}" method="POST" class="auth-form">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="form-row">
                 <div class="form-group">
                     <label for="first_name">First name</label>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.0
 flask-cors==4.0.0
 bcrypt==4.2.0
+Flask-WTF==1.2.1


### PR DESCRIPTION
- Add Flask-WTF==1.2.1 to requirements.txt
- Initialize CSRFProtect in app.py to protect all POST endpoints
- Add CSRFError handler returning 403 for invalid/missing tokens
- Add csrf_token hidden field to all 13 POST forms across templates:
  base.html (logout), login, register, booking create/cancel,
  adventure create, review create, and all admin action forms

Resolves #3

https://claude.ai/code/session_01741Vi3Qj9ATnAdw9vJu5aL