### PR TITLE
feat: add user profile editing flow (#13)

### DIFF
--- a/backend/controllers/portal_controller.py
+++ b/backend/controllers/portal_controller.py
@@ -9,6 +9,8 @@ MVC Role: CONTROLLER
 URL Prefix: /portal
 Routes:
     GET  /portal/                    - Customer dashboard
+    GET  /portal/profile             - Show and edit user profile
+    POST /portal/profile             - Update user profile
     GET  /portal/bookings            - View all bookings
     GET  /portal/bookings/new        - Show booking form
     POST /portal/bookings            - Submit booking request
@@ -26,6 +28,7 @@ from backend.models.booking import Booking
 from backend.models.review import Review
 from backend.models.adventure import Adventure, AdventureBooking
 from backend.models.property import Property
+from backend.models.user import User
 from backend.controllers.auth_controller import login_required
 
 portal_bp = Blueprint('portal', __name__, url_prefix='/portal')
@@ -49,6 +52,67 @@ def dashboard():
     return render_template('portal/dashboard.html',
                            bookings=bookings,
                            adventure_bookings=adventure_bookings)
+
+
+@portal_bp.route('/profile', methods=['GET'])
+@login_required
+def profile():
+    """Show the current user's profile details and edit form."""
+    user = User.get_by_id(session['user_id'])
+    if not user:
+        session.clear()
+        flash('Your account could not be found. Please log in again.', 'warning')
+        return redirect(url_for('auth.login'))
+
+    return render_template('portal/profile.html', form_data=user)
+
+
+@portal_bp.route('/profile', methods=['POST'])
+@login_required
+def profile_update():
+    """Update the current user's profile details."""
+    user_id = session['user_id']
+    user = User.get_by_id(user_id)
+    if not user:
+        session.clear()
+        flash('Your account could not be found. Please log in again.', 'warning')
+        return redirect(url_for('auth.login'))
+
+    first_name = request.form.get('first_name', '').strip()
+    last_name = request.form.get('last_name', '').strip()
+    email = request.form.get('email', '').strip()
+    form_data = {
+        'first_name': first_name,
+        'last_name': last_name,
+        'email': email
+    }
+
+    try:
+        updated_user = User.update(
+            user_id=user_id,
+            first_name=first_name,
+            last_name=last_name,
+            email=email
+        )
+        if not updated_user:
+            session.clear()
+            flash('Your account could not be found. Please log in again.', 'warning')
+            return redirect(url_for('auth.login'))
+
+        session['user_first_name'] = updated_user['first_name']
+        session['user_email'] = updated_user['email']
+
+        flash('Profile updated successfully.', 'success')
+        return redirect(url_for('portal.profile'))
+
+    except ValueError as e:
+        flash(str(e), 'error')
+        return render_template('portal/profile.html', form_data=form_data)
+
+    except Exception as e:
+        error_message = getattr(e, 'user_message', str(e))
+        flash(error_message, 'error')
+        return render_template('portal/profile.html', form_data=form_data)
 
 
 # ============================================================================

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -158,11 +158,20 @@ class User:
     def update(user_id: int, first_name: str, last_name: str,
                email: str, phone_number: str = None) -> Optional[Dict]:
         """Update an existing user's profile information."""
-        User.validate(email, first_name, last_name)
-
         existing = User.get_by_id(user_id)
         if not existing:
             return None
+
+        first_name = (first_name or '').strip()
+        last_name = (last_name or '').strip()
+        email = (email or '').strip()
+
+        if phone_number is None:
+            phone_number = existing.get('phone_number')
+        else:
+            phone_number = phone_number.strip() or None
+
+        User.validate(email, first_name, last_name)
 
         execute_query(
             "UPDATE users SET first_name=?, last_name=?, email=?, phone_number=?, updated_at=CURRENT_TIMESTAMP WHERE id=?",

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -25,6 +25,7 @@
                     <a href="{{ url_for('portal.bookings_index') }}" {% if request.endpoint and 'booking' in request.endpoint %}class="active"{% endif %}>My Bookings</a>
                     <a href="{{ url_for('portal.adventures_index') }}" {% if request.endpoint and 'adventure' in request.endpoint %}class="active"{% endif %}>Adventures</a>
                 {% endif %}
+                <a href="{{ url_for('portal.profile') }}" {% if request.endpoint and request.endpoint.startswith('portal.profile') %}class="active"{% endif %}>Profile</a>
                 <div class="nav-user">
                     <span class="user-greeting">Hi, {{ current_user_name }}
                         {% if is_admin %}<span class="role-badge admin">Admin</span>{% endif %}

--- a/backend/templates/portal/profile.html
+++ b/backend/templates/portal/profile.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% block title %}My Profile{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <div>
+        <h1>My Profile</h1>
+        <p class="subtitle">View and update your account details</p>
+    </div>
+</div>
+
+<div class="form-page">
+    <div class="form-card">
+        <form action="{{ url_for('portal.profile_update') }}" method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="first_name">First name</label>
+                    <input
+                        type="text"
+                        id="first_name"
+                        name="first_name"
+                        value="{{ form_data.get('first_name', '') }}"
+                        required
+                    >
+                </div>
+                <div class="form-group">
+                    <label for="last_name">Last name</label>
+                    <input
+                        type="text"
+                        id="last_name"
+                        name="last_name"
+                        value="{{ form_data.get('last_name', '') }}"
+                        required
+                    >
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="email">Email address</label>
+                <input
+                    type="email"
+                    id="email"
+                    name="email"
+                    value="{{ form_data.get('email', '') }}"
+                    placeholder="you@example.com"
+                    required
+                >
+            </div>
+
+            <div class="form-actions">
+                <a href="{{ url_for('portal.dashboard') }}" class="btn btn-outline">Back to Dashboard</a>
+                <button type="submit" class="btn btn-primary">Save Changes</button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_user_profile_editing.py
+++ b/tests/test_user_profile_editing.py
@@ -1,0 +1,126 @@
+"""Integration tests for profile editing in the portal."""
+
+import os
+import sqlite3
+
+
+def _set_logged_in_session(client, user_id=1, email='test@example.com', first_name='Test', role='customer'):
+    with client.session_transaction() as sess:
+        sess['user_id'] = user_id
+        sess['user_email'] = email
+        sess['user_first_name'] = first_name
+        sess['user_role'] = role
+
+
+def _get_user_row(user_id):
+    db_path = os.environ["DATABASE_PATH"]
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT id, email, first_name, last_name, phone_number FROM users WHERE id = ?",
+        (user_id,),
+    ).fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def test_profile_page_requires_authentication(app, seed_user):
+    client = app.test_client()
+
+    response = client.get('/portal/profile', follow_redirects=False)
+
+    assert response.status_code == 302
+    assert '/auth/login' in response.headers['Location']
+
+
+def test_authenticated_user_can_view_profile_page(app, seed_user):
+    client = app.test_client()
+    _set_logged_in_session(client)
+
+    response = client.get('/portal/profile')
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'My Profile' in body
+    assert 'value="Test"' in body
+    assert 'value="User"' in body
+    assert 'value="test@example.com"' in body
+
+
+def test_profile_update_persists_and_refreshes_session_values(app, seed_user):
+    client = app.test_client()
+    _set_logged_in_session(client)
+
+    db_path = os.environ["DATABASE_PATH"]
+    conn = sqlite3.connect(db_path)
+    conn.execute("UPDATE users SET phone_number = ? WHERE id = ?", ("555-1111", 1))
+    conn.commit()
+    conn.close()
+
+    response = client.post(
+        '/portal/profile',
+        data={
+            'first_name': 'Updated',
+            'last_name': 'Person',
+            'email': 'updated@example.com',
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert 'Profile updated successfully.' in response.get_data(as_text=True)
+
+    updated = _get_user_row(1)
+    assert updated is not None
+    assert updated['first_name'] == 'Updated'
+    assert updated['last_name'] == 'Person'
+    assert updated['email'] == 'updated@example.com'
+    assert updated['phone_number'] == '555-1111'
+
+    with client.session_transaction() as sess:
+        assert sess['user_first_name'] == 'Updated'
+        assert sess['user_email'] == 'updated@example.com'
+
+
+def test_profile_update_rejects_invalid_email(app, seed_user):
+    client = app.test_client()
+    _set_logged_in_session(client)
+
+    response = client.post(
+        '/portal/profile',
+        data={
+            'first_name': 'Test',
+            'last_name': 'User',
+            'email': 'not-an-email',
+        },
+        follow_redirects=True,
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert 'Invalid email format: not-an-email' in body
+
+    user = _get_user_row(1)
+    assert user['email'] == 'test@example.com'
+
+
+def test_profile_update_rejects_duplicate_email(app, seed_user):
+    client = app.test_client()
+    _set_logged_in_session(client)
+
+    response = client.post(
+        '/portal/profile',
+        data={
+            'first_name': 'Test',
+            'last_name': 'User',
+            'email': 'test2@example.com',
+        },
+        follow_redirects=True,
+    )
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert 'An account with this email already exists' in body
+
+    user = _get_user_row(1)
+    assert user['email'] == 'test@example.com'


### PR DESCRIPTION
## Summary
- add `/portal/profile` GET/POST handlers to render and process profile updates for authenticated users
- wire profile updates to `User.update()` and refresh session-backed UI fields after successful updates
- add a new profile template, shared nav link, and integration tests for success, validation, uniqueness, and auth redirect behavior

## Test plan
- [x] `pytest` (currently fails during collection in this repo due existing duplicate `conftest` import-path mismatch between `tests/` and `backend/tests/`)
- [x] `pytest tests`
- [x] `SECRET_KEY=test-secret-key-not-for-production PYTHONPATH=. pytest backend/tests`


Made with [Cursor](https://cursor.com)