### PR TITLE
feat(admin): add detail view and navigation for adventure bookings (#48)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -235,6 +235,7 @@ CREATE TABLE adventure_bookings_new (
     status TEXT NOT NULL DEFAULT 'pending'
         CHECK (status IN ('pending', 'approved', 'rejected', 'cancelled')),
     special_requests TEXT,
+    admin_notes TEXT,
     total_price REAL NOT NULL DEFAULT 0 CHECK (total_price >= 0),
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -249,7 +250,7 @@ CREATE TABLE adventure_bookings_new (
 
 _ADV_BOOKINGS_COPY_COLS = (
     "id, user_id, adventure_id, booking_id, scheduled_date, participants, status, "
-    "special_requests, total_price, created_at, updated_at"
+    "special_requests, admin_notes, total_price, created_at, updated_at"
 )
 
 
@@ -333,6 +334,7 @@ def init_database():
                 "ALTER TABLE users ADD COLUMN email_verification_token TEXT",
                 "ALTER TABLE users ADD COLUMN email_verification_expires DATETIME",
                 "ALTER TABLE users ADD COLUMN email_verified INTEGER NOT NULL DEFAULT 1",
+                "ALTER TABLE adventure_bookings ADD COLUMN admin_notes TEXT",
             ]:
                 try:
                     conn.execute(migration)

--- a/backend/controllers/admin_controller.py
+++ b/backend/controllers/admin_controller.py
@@ -23,6 +23,7 @@ Routes:
     POST /admin/adventures/<id>           - Update adventure
     POST /admin/adventures/<id>/deactivate - Deactivate adventure
     GET  /admin/adventure-bookings        - Adventure bookings
+    GET  /admin/adventure-bookings/<id> - View adventure booking
     POST /admin/adventure-bookings/<id>/approve - Approve adventure booking
     POST /admin/adventure-bookings/<id>/reject  - Reject adventure booking
     GET  /admin/users                     - Manage users
@@ -333,31 +334,50 @@ def adventure_bookings_index():
     return render_template('admin/adventure_bookings.html', bookings=bookings, current_status=status)
 
 
+@admin_bp.route('/adventure-bookings/<int:ab_id>')
+@admin_required
+def adventure_bookings_show(ab_id):
+    """View a single adventure booking's full details."""
+    booking = AdventureBooking.get_by_id(ab_id, include_relations=True)
+    if not booking:
+        flash('Adventure booking not found.', 'error')
+        return redirect(url_for('admin.adventure_bookings_index'))
+    return render_template('admin/adventure_booking_detail.html', booking=booking)
+
+
 @admin_bp.route('/adventure-bookings/<int:ab_id>/approve', methods=['POST'])
 @admin_required
 def adventure_bookings_approve(ab_id):
     """Approve an adventure booking."""
+    admin_notes = request.form.get('admin_notes', '').strip() or None
     try:
-        ab = AdventureBooking.update_status(ab_id, 'approved')
+        ab = AdventureBooking.update_status(ab_id, 'approved', admin_notes)
         if not ab:
             flash('Adventure booking not found.', 'error')
         else:
             flash('Adventure booking approved.', 'success')
     except ValueError as e:
         flash(str(e), 'error')
-    return redirect(url_for('admin.adventure_bookings_index'))
+    return redirect(url_for('admin.adventure_bookings_show', ab_id=ab_id))
 
 
 @admin_bp.route('/adventure-bookings/<int:ab_id>/reject', methods=['POST'])
 @admin_required
 def adventure_bookings_reject(ab_id):
     """Reject an adventure booking."""
-    ab = AdventureBooking.update_status(ab_id, 'rejected')
-    if not ab:
-        flash('Adventure booking not found.', 'error')
-    else:
-        flash('Adventure booking rejected.', 'success')
-    return redirect(url_for('admin.adventure_bookings_index'))
+    admin_notes = request.form.get('admin_notes', '').strip() or None
+    if not admin_notes:
+        flash('A reason is required when rejecting an adventure booking.', 'error')
+        return redirect(url_for('admin.adventure_bookings_show', ab_id=ab_id))
+    try:
+        ab = AdventureBooking.update_status(ab_id, 'rejected', admin_notes)
+        if not ab:
+            flash('Adventure booking not found.', 'error')
+        else:
+            flash('Adventure booking rejected.', 'success')
+    except ValueError as e:
+        flash(str(e), 'error')
+    return redirect(url_for('admin.adventure_bookings_show', ab_id=ab_id))
 
 
 # ============================================================================

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -135,6 +135,7 @@ CREATE TABLE IF NOT EXISTS adventure_bookings (
     status TEXT NOT NULL DEFAULT 'pending'
         CHECK (status IN ('pending', 'approved', 'rejected', 'cancelled')),
     special_requests TEXT,
+    admin_notes TEXT,
     total_price REAL NOT NULL DEFAULT 0 CHECK (total_price >= 0),
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/backend/models/adventure.py
+++ b/backend/models/adventure.py
@@ -405,7 +405,7 @@ class AdventureBooking:
         return bookings
 
     @staticmethod
-    def update_status(ab_id: int, status: str) -> Optional[Dict]:
+    def update_status(ab_id: int, status: str, admin_notes: str = None) -> Optional[Dict]:
         """Update adventure booking status (admin action)."""
         if status not in AdventureBooking.VALID_STATUSES:
             raise ValueError(f"Status must be one of {AdventureBooking.VALID_STATUSES}")
@@ -437,13 +437,13 @@ class AdventureBooking:
                         "Cannot approve: maximum participants for this date would be exceeded."
                     )
                 execute_query(
-                    "UPDATE adventure_bookings SET status=?, updated_at=CURRENT_TIMESTAMP WHERE id=?",
-                    (status, ab_id), commit=True
+                    "UPDATE adventure_bookings SET status=?, admin_notes=?, updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                    (status, admin_notes, ab_id), commit=True
                 )
             return AdventureBooking.get_by_id(ab_id, include_relations=True)
 
         execute_query(
-            "UPDATE adventure_bookings SET status=?, updated_at=CURRENT_TIMESTAMP WHERE id=?",
-            (status, ab_id), commit=True
+            "UPDATE adventure_bookings SET status=?, admin_notes=?, updated_at=CURRENT_TIMESTAMP WHERE id=?",
+            (status, admin_notes, ab_id), commit=True
         )
         return AdventureBooking.get_by_id(ab_id, include_relations=True)

--- a/backend/templates/admin/adventure_booking_detail.html
+++ b/backend/templates/admin/adventure_booking_detail.html
@@ -1,0 +1,124 @@
+{% extends "base.html" %}
+{% block title %}Adventure Booking #{{ booking.id }}{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <div>
+        <h1>Adventure Booking #{{ booking.id }}</h1>
+        <p class="subtitle">{{ booking.user.first_name }} {{ booking.user.last_name }} — {{ booking.adventure.name }}</p>
+    </div>
+    <a href="{{ url_for('admin.adventure_bookings_index') }}" class="btn btn-outline">&larr; All Adventure Bookings</a>
+</div>
+
+<div class="filter-tabs" style="margin-bottom: 0.5rem;">
+    <a href="{{ url_for('admin.adventures_index') }}" class="filter-tab">Catalog</a>
+    <a href="{{ url_for('admin.adventure_bookings_index') }}" class="filter-tab active">Bookings</a>
+</div>
+
+<div class="detail-layout">
+    <div class="detail-main">
+        <div class="detail-card">
+            <div class="detail-card-header">
+                <h2>Booking Details</h2>
+                <span class="badge badge-{{ booking.status }} badge-lg">{{ booking.status }}</span>
+            </div>
+
+            <div class="detail-grid">
+                <div class="detail-item">
+                    <span class="detail-label">Guest</span>
+                    <span class="detail-value">{{ booking.user.first_name }} {{ booking.user.last_name }}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Email</span>
+                    <span class="detail-value">{{ booking.user.email }}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Adventure</span>
+                    <span class="detail-value">{{ booking.adventure.name }}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Category</span>
+                    <span class="detail-value">{{ booking.adventure.category }}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Difficulty</span>
+                    <span class="detail-value">{{ booking.adventure.difficulty }}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Scheduled Date</span>
+                    <span class="detail-value">{{ booking.scheduled_date }}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Participants</span>
+                    <span class="detail-value">{{ booking.participants }}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Total Price</span>
+                    <span class="detail-value price">${{ "%.2f" | format(booking.total_price) }}</span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">Submitted</span>
+                    <span class="detail-value">{{ booking.created_at[:10] }}</span>
+                </div>
+                {% if booking.booking_id %}
+                <div class="detail-item">
+                    <span class="detail-label">Linked Stay</span>
+                    <span class="detail-value"><a href="{{ url_for('admin.bookings_show', booking_id=booking.booking_id) }}">Booking #{{ booking.booking_id }}</a></span>
+                </div>
+                {% endif %}
+            </div>
+
+            {% if booking.special_requests %}
+            <div class="detail-notes">
+                <span class="detail-label">Special Requests</span>
+                <p>{{ booking.special_requests }}</p>
+            </div>
+            {% endif %}
+
+            {% if booking.admin_notes %}
+            <div class="detail-notes admin-notes">
+                <span class="detail-label">Host Notes</span>
+                <p>{{ booking.admin_notes }}</p>
+            </div>
+            {% endif %}
+        </div>
+
+        {% if booking.status == 'pending' %}
+        <div class="admin-actions">
+            <h3>Take Action</h3>
+            <div class="action-forms">
+                <form action="{{ url_for('admin.adventure_bookings_approve', ab_id=booking.id) }}" method="POST" class="action-form">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="form-group">
+                        <label for="approve_notes">Note to guest (optional)</label>
+                        <input type="text" id="approve_notes" name="admin_notes"
+                               placeholder="e.g. Looking forward to the adventure!">
+                    </div>
+                    <button type="submit" class="btn btn-success">Approve Booking</button>
+                </form>
+
+                <form action="{{ url_for('admin.adventure_bookings_reject', ab_id=booking.id) }}" method="POST" class="action-form">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="form-group">
+                        <label for="reject_notes">Reason for rejection <span class="required">*</span></label>
+                        <input type="text" id="reject_notes" name="admin_notes"
+                               placeholder="e.g. Activity unavailable on this date" required>
+                    </div>
+                    <button type="submit" class="btn btn-danger">Reject Booking</button>
+                </form>
+            </div>
+        </div>
+        {% endif %}
+    </div>
+
+    <div class="detail-sidebar">
+        <div class="info-card">
+            <h3>Quick Actions</h3>
+            <ul class="quick-links">
+                <li><a href="{{ url_for('admin.adventure_bookings_index') }}?status=pending">View all pending</a></li>
+                <li><a href="{{ url_for('admin.adventures_index') }}">Adventure catalog</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/backend/templates/admin/adventure_bookings.html
+++ b/backend/templates/admin/adventure_bookings.html
@@ -9,6 +9,11 @@
     </div>
 </div>
 
+<div class="filter-tabs" style="margin-bottom: 0.5rem;">
+    <a href="{{ url_for('admin.adventures_index') }}" class="filter-tab">Catalog</a>
+    <a href="{{ url_for('admin.adventure_bookings_index') }}" class="filter-tab active">Bookings</a>
+</div>
+
 <div class="filter-tabs">
     <a href="{{ url_for('admin.adventure_bookings_index') }}"
        class="filter-tab {% if not current_status %}active{% endif %}">All</a>
@@ -38,7 +43,7 @@
         <tbody>
             {% for ab in bookings %}
             <tr class="{% if ab.status == 'pending' %}row-highlight{% endif %}">
-                <td class="text-muted">#{{ ab.id }}</td>
+                <td><a href="{{ url_for('admin.adventure_bookings_show', ab_id=ab.id) }}">#{{ ab.id }}</a></td>
                 <td>
                     <strong>{{ ab.user.first_name }} {{ ab.user.last_name }}</strong>
                     <div class="text-sm text-muted">{{ ab.user.email }}</div>
@@ -49,20 +54,7 @@
                 <td>${{ "%.2f" | format(ab.total_price) }}</td>
                 <td><span class="badge badge-{{ ab.status }}">{{ ab.status }}</span></td>
                 <td>
-                    {% if ab.status == 'pending' %}
-                    <form action="{{ url_for('admin.adventure_bookings_approve', ab_id=ab.id) }}" method="POST" style="display:inline">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <button type="submit" class="btn btn-success btn-sm">✓</button>
-                    </form>
-                    <form action="{{ url_for('admin.adventure_bookings_reject', ab_id=ab.id) }}" method="POST"
-                          style="display:inline"
-                          onsubmit="return confirm('Reject this adventure booking?')">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <button type="submit" class="btn btn-danger btn-sm">✗</button>
-                    </form>
-                    {% else %}
-                        <span class="text-muted text-sm">—</span>
-                    {% endif %}
+                    <a href="{{ url_for('admin.adventure_bookings_show', ab_id=ab.id) }}" class="btn btn-outline btn-sm">View</a>
                 </td>
             </tr>
             {% endfor %}

--- a/backend/templates/admin/adventures.html
+++ b/backend/templates/admin/adventures.html
@@ -10,6 +10,11 @@
     <a href="{{ url_for('admin.adventures_new') }}" class="btn btn-primary">+ Add Adventure</a>
 </div>
 
+<div class="filter-tabs" style="margin-bottom: 0.5rem;">
+    <a href="{{ url_for('admin.adventures_index') }}" class="filter-tab active">Catalog</a>
+    <a href="{{ url_for('admin.adventure_bookings_index') }}" class="filter-tab">Bookings</a>
+</div>
+
 {% if adventures %}
 <div class="table-container">
     <table class="table">


### PR DESCRIPTION
Add a dedicated detail page for adventure bookings with admin notes support, sub-navigation tabs between catalog and bookings, and linked list rows — matching the existing stay booking detail pattern.