### PR TITLE
fix(admin): default Adventures nav to pending adventure bookings

### DIFF
--- a/backend/controllers/admin_controller.py
+++ b/backend/controllers/admin_controller.py
@@ -329,7 +329,9 @@ def adventures_deactivate(adventure_id):
 @admin_required
 def adventure_bookings_index():
     """View all adventure booking requests."""
-    status = request.args.get('status')
+    status = request.args.get('status', 'pending')
+    if status == 'all':
+        status = None
     bookings = AdventureBooking.get_all(status=status)
     return render_template('admin/adventure_bookings.html', bookings=bookings, current_status=status)
 

--- a/backend/templates/admin/adventure_bookings.html
+++ b/backend/templates/admin/adventure_bookings.html
@@ -15,7 +15,7 @@
 </div>
 
 <div class="filter-tabs">
-    <a href="{{ url_for('admin.adventure_bookings_index') }}"
+    <a href="?status=all"
        class="filter-tab {% if not current_status %}active{% endif %}">All</a>
     <a href="?status=pending"
        class="filter-tab {% if current_status == 'pending' %}active{% endif %}">Pending</a>

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -19,7 +19,7 @@
                     <a href="{{ url_for('admin.bookings_index') }}" {% if request.endpoint == 'admin.bookings_index' %}class="active"{% endif %}>Bookings</a>
                     <a href="{{ url_for('admin.reviews_index') }}" {% if request.endpoint == 'admin.reviews_index' %}class="active"{% endif %}>Reviews</a>
                     <a href="{{ url_for('admin.properties_index') }}" {% if request.endpoint and 'properties' in request.endpoint %}class="active"{% endif %}>Properties</a>
-                    <a href="{{ url_for('admin.adventures_index') }}" {% if request.endpoint and (request.endpoint.startswith('admin.adventures_') or request.endpoint.startswith('admin.adventure_bookings_')) %}class="active"{% endif %}>Adventures</a>
+                    <a href="{{ url_for('admin.adventure_bookings_index', status='pending') }}" {% if request.endpoint and (request.endpoint.startswith('admin.adventures_') or request.endpoint.startswith('admin.adventure_bookings_')) %}class="active"{% endif %}>Adventures</a>
                     <a href="{{ url_for('admin.users_index') }}" {% if request.endpoint == 'admin.users_index' %}class="active"{% endif %}>Users</a>
                 {% else %}
                     <a href="{{ url_for('portal.dashboard') }}" {% if request.endpoint == 'portal.dashboard' %}class="active"{% endif %}>Dashboard</a>


### PR DESCRIPTION
Navigate directly to the Bookings tab with Pending filter instead of landing on Catalog then requiring two extra clicks to reach pending items.